### PR TITLE
Get Chapter 11 to build using the latest libtorch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+libtorch/

--- a/Chapter11/pytorch/CMakeLists.txt
+++ b/Chapter11/pytorch/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(Torch REQUIRED)
 include_directories(${TORCH_INCLUDE_DIRS})
 include_directories(${Boost_INCLUDE_DIRS})
 
+set(CMAKE_CXX_FLAGS "-pthread")
 # set(CMAKE_CXX_FLAGS "-msse3 -fopenmp -Wall -Wextra -Wno-unused-parameter -pthread -fopenmp")
 # set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 # set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -O0")

--- a/Chapter11/pytorch/CMakeLists.txt
+++ b/Chapter11/pytorch/CMakeLists.txt
@@ -1,17 +1,19 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(rnn-pytorch)
 
-find_package(Torch REQUIRED)
+include(CMakePrintHelpers) # cmake_print_variables(VAR)
+include(FetchContent)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 17)
 
+find_package(Torch REQUIRED)
 include_directories(${TORCH_INCLUDE_DIRS})
 include_directories(${Boost_INCLUDE_DIRS})
 
-set(CMAKE_CXX_FLAGS "-msse3 -fopenmp -Wall -Wextra -Wno-unused-parameter -pthread -fopenmp")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -O0")
+# set(CMAKE_CXX_FLAGS "-msse3 -fopenmp -Wall -Wextra -Wno-unused-parameter -pthread -fopenmp")
+# set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+# set(CMAKE_CXX_FLAGS_DEBUG "-ggdb -O0")
 
 set(SOURCE_FILES main.cc
                  imdbdataset.h
@@ -26,8 +28,8 @@ set(SOURCE_FILES main.cc
                  vocabulary.cc
                  )
 
-set(REQUIRED_LIBS "stdc++fs")
-list(APPEND REQUIRED_LIBS ${TORCH_LIBRARIES})
+set(REQUIRED_LIBS "stdc++fs" "${TORCH_LIBRARIES}")
+# list(APPEND REQUIRED_LIBS ${TORCH_LIBRARIES})
 
 
 add_executable("${CMAKE_PROJECT_NAME}" ${SOURCE_FILES})

--- a/Chapter11/pytorch/README
+++ b/Chapter11/pytorch/README
@@ -1,0 +1,15 @@
+# Setup
+Download pytorch (libtorch)
+```
+wget https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip
+unzip libtorch-shared-with-deps-latest.zip
+```
+Install
+```
+cmake -DCMAKE_PREFIX_PATH=~/path-to/libtorch -B build
+cd build
+make all
+```
+Note: You could also use your own build system using the `-G` flag, e.g., `-G Ninja`.
+
+

--- a/Chapter11/pytorch/main.cc
+++ b/Chapter11/pytorch/main.cc
@@ -1,3 +1,7 @@
+/*
+PR's that introduced breaking changes:
+  https://github.com/pytorch/pytorch/pull/27422
+*/
 #include "glovedict.h"
 #include "imdbdataset.h"
 #include "imdbreader.h"
@@ -91,7 +95,7 @@ void TrainModel(
     // Compute a loss value to estimate error of our model
     // target should have size of [batch_size]
     torch::Tensor loss = torch::binary_cross_entropy_with_logits(
-        prediction, labels, {}, {}, Reduction::Mean);
+        prediction, labels, {}, {}, torch::Reduction::Mean);
 
     // Compute gradients of the loss and parameters of our model
     loss.backward();
@@ -144,7 +148,7 @@ void TestModel(
     // Compute a loss value to estimate error of our model
     // target should have size of [batch_size]
     torch::Tensor loss = torch::binary_cross_entropy_with_logits(
-        prediction, labels, {}, {}, Reduction::Mean);
+        prediction, labels, {}, {}, torch::Reduction::Mean);
 
     auto loss_value = static_cast<double>(loss.item<float>());
     auto acc_value = static_cast<double>(BinaryAccuracy(prediction, labels));

--- a/Chapter11/pytorch/rnn.cc
+++ b/Chapter11/pytorch/rnn.cc
@@ -26,7 +26,7 @@ std::vector<torch::Tensor> PackedLSTMImpl::flat_weights() const {
   return flat;
 }
 
-torch::nn::RNNOutput PackedLSTMImpl::forward(const torch::Tensor& input,
+std::tuple<torch::Tensor, torch::Tensor> PackedLSTMImpl::forward(const torch::Tensor& input,
                                              const at::Tensor& lengths,
                                              torch::Tensor state) {
   if (!state.defined()) {

--- a/Chapter11/pytorch/rnn.cc
+++ b/Chapter11/pytorch/rnn.cc
@@ -99,7 +99,7 @@ torch::Tensor SentimentRNNImpl::forward(const at::Tensor& text,
   auto rnn_out = rnn_->forward(packed_text, packed_length);
   // rnn_out = {output, torch::stack({hidden_state, cell_state})}
 
-  auto hidden_state = rnn_out.state.narrow(0, 0, 1);
+  auto hidden_state = std::get<1>(rnn_out).narrow(0, 0, 1);
   hidden_state.squeeze_(0);  // remove 0 dimension equals to 1 after narrowing
 
   // take last hidden layers state

--- a/Chapter11/pytorch/rnn.cc
+++ b/Chapter11/pytorch/rnn.cc
@@ -10,7 +10,7 @@ std::vector<torch::Tensor> PackedLSTMImpl::flat_weights() const {
   // (w_ih, w_hh, b_ih, b_hh), repeated for each layer (next to each other).
   std::vector<torch::Tensor> flat;
 
-  const auto num_directions = rnn_->options.bidirectional_ ? 2 : 1;
+  const auto num_directions = rnn_->options.bidirectional() ? 2 : 1;
   for (int64_t layer = 0; layer < rnn_->options.num_layers_; layer++) {
     for (auto direction = 0; direction < num_directions; direction++) {
       const auto layer_idx =
@@ -33,7 +33,7 @@ std::tuple<torch::Tensor, torch::Tensor> PackedLSTMImpl::forward(const torch::Te
     // 2 for hidden state and cell state, then #layers, batch size, state size
     // const auto batch_size = input.size(rnn_->options.batch_first_ ? 0 : 1);
     const auto max_batch_size = lengths[0].item().toLong();
-    const auto num_directions = rnn_->options.bidirectional_ ? 2 : 1;
+    const auto num_directions = rnn_->options.bidirectional() ? 2 : 1;
     state = torch::zeros({2, rnn_->options.num_layers_ * num_directions,
                           max_batch_size, rnn_->options.hidden_size_},
                          input.options());
@@ -42,7 +42,7 @@ std::tuple<torch::Tensor, torch::Tensor> PackedLSTMImpl::forward(const torch::Te
   std::tie(output, hidden_state, cell_state) = torch::lstm(
       input, lengths, {state[0], state[1]}, flat_weights(),
       rnn_->options.with_bias_, rnn_->options.num_layers_, rnn_->options.dropout_,
-      rnn_->is_training(), rnn_->options.bidirectional_);
+      rnn_->is_training(), rnn_->options.bidirectional());
   return {output, torch::stack({hidden_state, cell_state})};
 }
 

--- a/Chapter11/pytorch/rnn.cc
+++ b/Chapter11/pytorch/rnn.cc
@@ -7,7 +7,8 @@ PackedLSTMImpl::PackedLSTMImpl(const torch::nn::LSTMOptions& options) {
 
 std::vector<torch::Tensor> PackedLSTMImpl::flat_weights() const {
   // Organize all weights in a flat vector in the order
-  // (w_ih, w_hh, b_ih, b_hh), repeated for each layer (next to each other).
+  // (weight_ih_l0, weight_hh_l0, bias_ih_l0, bias_hh_l0)
+  // repeated for each layer (next to each other).
   std::vector<torch::Tensor> flat;
 
   const auto num_directions = rnn_->options.bidirectional() ? 2 : 1;
@@ -15,11 +16,11 @@ std::vector<torch::Tensor> PackedLSTMImpl::flat_weights() const {
     for (auto direction = 0; direction < num_directions; direction++) {
       const auto layer_idx =
           static_cast<size_t>((layer * num_directions) + direction);
-      flat.push_back(rnn_->w_ih[layer_idx]);
-      flat.push_back(rnn_->w_hh[layer_idx]);
+      flat.push_back(rnn_->named_parameters()["weight_ih_l0"][layer_idx]);
+      flat.push_back(rnn_->named_parameters()["weight_hh_l0"][layer_idx]);
       if (rnn_->options.bias()) {
-        flat.push_back(rnn_->b_ih[layer_idx]);
-        flat.push_back(rnn_->b_hh[layer_idx]);
+        flat.push_back(rnn_->named_parameters()["bias_ih_l0"][layer_idx]);
+        flat.push_back(rnn_->named_parameters()["bias_hh_l0"][layer_idx]);
       }
     }
   }

--- a/Chapter11/pytorch/rnn.h
+++ b/Chapter11/pytorch/rnn.h
@@ -1,7 +1,12 @@
 /*
-PR introduced breaking changes: https://github.com/pytorch/pytorch/pull/34322
-*/
+PR's that introduced breaking changes:
+  https://github.com/pytorch/pytorch/pull/34322
 
+W_ih = torch_rnn.weight_ih_l0.detach()
+b_ih = torch_rnn.bias_ih_l0.detach()
+W_hh = torch_rnn.weight_hh_l0.detach()
+b_hh = torch_rnn.bias_hh_l0.detach()
+*/
 #ifndef LENET5_H
 #define LENET5_H
 

--- a/Chapter11/pytorch/rnn.h
+++ b/Chapter11/pytorch/rnn.h
@@ -1,3 +1,7 @@
+/*
+PR introduced breaking changes: https://github.com/pytorch/pytorch/pull/34322
+*/
+
 #ifndef LENET5_H
 #define LENET5_H
 
@@ -9,7 +13,7 @@ class PackedLSTMImpl : public torch::nn::Module {
 
   std::vector<torch::Tensor> flat_weights() const;
 
-  torch::nn::RNNOutput forward(const torch::Tensor& input,
+  std::tuple<torch::Tensor, torch::Tensor> forward(const torch::Tensor& input,
                                const torch::Tensor& lengths,
                                torch::Tensor state = {});
 


### PR DESCRIPTION
The book's code from 2020 is out of date with respect to the latest libtorch. Can't get hands-on if the code can't compile, especially since the build script doesn't specify and exact version.

The pull-request from https://github.com/pytorch/pytorch/pull/34322 broke a handful of items from the API
- Weights have to be accessed via namespace_parameters to match the pytorch python API
- Many attributes were set to private and accessed via getters
- torch::nn::RNNOutput has been deprecated in favor of a tuple of tensors to match the pytorch python API

The pull-request from https://github.com/pytorch/pytorch/pull/27422 rewrapped a few functions into torch
- Reduction::mean is now accessible as torch::Reduction::mean 