### PR TITLE
Fix installation environment setup and compatibility issues

### DIFF
--- a/env_scripts/dockerfile
+++ b/env_scripts/dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER Kirill rotate@ukr.net
+LABEL org.opencontainers.image.authors="Kirill rotate@ukr.net"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -37,6 +37,7 @@ RUN apt-get install -y libopencv-highgui3.2
 RUN apt-get install -y libopencv-highgui-dev
 RUN apt-get install -y libhdf5-dev
 RUN apt-get install -y libjson-c-dev
+RUN apt-get install -y libssl-dev
 RUN apt-get install -y libx11-dev
 RUN apt-get install -y openjdk-8-jdk
 RUN apt-get install -y wget

--- a/env_scripts/install_env.sh
+++ b/env_scripts/install_env.sh
@@ -32,7 +32,7 @@ mkdir libs/sources
 . ./install_lib.sh https://github.com/Tencent/rapidjson 73063f5002612c6bf64fe24f851cd5cc0d83eef9
 
 # mlpack
-. ./install_lib.sh https://github.com/mlpack/mlpack e2f696cfd5b7ccda2d3af1c7c728483ea6591718 -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_TESTS=OFF -DDOWNLOAD_ENSMALLEN=ON
+. ./install_lib.sh https://github.com/mlpack/mlpack e2f696cfd5b7ccda2d3af1c7c728483ea6591718 -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_TESTS=OFF -DENSMALLEN_INCLUDE_DIR="$DEV_DIR/libs/include"
 
 # Eigen
 . ./install_lib.sh https://github.com/eigenteam/eigen-git-mirror cf794d3b741a6278df169e58461f8529f43bce5d

--- a/env_scripts/install_lib.sh
+++ b/env_scripts/install_lib.sh
@@ -9,15 +9,51 @@ shift; shift;
 EXTRA_CMAKE_PARAMS=$@
 
 cd $START_DIR/libs/sources
-git clone $REPOSITORY
-cd "$(basename "$REPOSITORY" .git)"
-git checkout $COMMIT_HASH
 
-if [ -f ".gitmodules" ];then
-sed -i 's/git:\/\//https:\/\//g' ".gitmodules"
+if [ "$REPOSITORY" = "https://gitlab.com/conradsnicta/armadillo-code" ] && [ "$COMMIT_HASH" = "48b45db6ca1d2839e42332dcdf04f55dcec83e20" ]; then
+    ZIP_URL="https://gitlab.com/conradsnicta/armadillo-code/-/archive/48b45db6ca1d2839e42332dcdf04f55dcec83e20/armadillo-code-48b45db6ca1d2839e42332dcdf04f55dcec83e20.zip"
+    ZIP_FILE="armadillo-code-48b45db6ca1d2839e42332dcdf04f55dcec83e20.zip"
+    DIR_NAME="armadillo-code-48b45db6ca1d2839e42332dcdf04f55dcec83e20"
+
+    wget "$ZIP_URL" -O "$ZIP_FILE"
+    unzip "$ZIP_FILE"
+    rm "$ZIP_FILE"
+    cd "$DIR_NAME"
+elif [ "$REPOSITORY" = "https://github.com/mlpack/mlpack.git" ] && [ "$COMMIT_HASH" = "e2f696cfd5b7ccda2d3af1c7c728483ea6591718" ]; then
+    ENSMALLEN_URL="https://www.ensmallen.org/files/ensmallen-1.10.0.tar.gz"
+    ENSMALLEN_FILE="ensmallen-1.10.0.tar.gz"
+    ENSMALLEN_DIR="ensmallen-1.10.0"
+
+    wget "$ENSMALLEN_URL" -O "$ENSMALLEN_FILE"
+    tar -xzf "$ENSMALLEN_FILE"
+    rm "$ENSMALLEN_FILE"
+    cd "$ENSMALLEN_DIR"
+    mkdir build
+    cd build
+    cmake -DCMAKE_INSTALL_PREFIX="$START_DIR/libs" ..
+    cmake --build . --target install -- -j8
+    cd ../..
+    rm -rf "$ENSMALLEN_DIR"
+
+    git clone "$REPOSITORY"
+    cd "$(basename "$REPOSITORY" .git)"
+    git checkout "$COMMIT_HASH"
+
+    if [ -f ".gitmodules" ]; then
+        sed -i 's/git:\/\//https:\/\//g' ".gitmodules"
+        git submodule update --init --recursive
+    fi
+else
+    git clone "$REPOSITORY"
+    cd "$(basename "$REPOSITORY" .git)"
+    git checkout "$COMMIT_HASH"
+
+    if [ -f ".gitmodules" ]; then
+        sed -i 's/git:\/\//https:\/\//g' ".gitmodules"
+        git submodule update --init --recursive
+    fi
 fi
 
-git submodule update --init --recursive
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=$START_DIR/libs $EXTRA_CMAKE_PARAMS ..

--- a/env_scripts/install_lib.sh
+++ b/env_scripts/install_lib.sh
@@ -19,7 +19,7 @@ if [ "$REPOSITORY" = "https://gitlab.com/conradsnicta/armadillo-code" ] && [ "$C
     unzip "$ZIP_FILE"
     rm "$ZIP_FILE"
     cd "$DIR_NAME"
-elif [ "$REPOSITORY" = "https://github.com/mlpack/mlpack.git" ] && [ "$COMMIT_HASH" = "e2f696cfd5b7ccda2d3af1c7c728483ea6591718" ]; then
+elif [ "$REPOSITORY" = "https://github.com/mlpack/mlpack" ] && [ "$COMMIT_HASH" = "e2f696cfd5b7ccda2d3af1c7c728483ea6591718" ]; then
     ENSMALLEN_URL="https://www.ensmallen.org/files/ensmallen-1.10.0.tar.gz"
     ENSMALLEN_FILE="ensmallen-1.10.0.tar.gz"
     ENSMALLEN_DIR="ensmallen-1.10.0"


### PR DESCRIPTION
## Description

This pull request resolves two key issues in the installation environment setup:

1. The Armadillo commit `48b45db6ca1d2839e42332dcdf04f55dcec83e20` is from a deleted branch and cannot be checked out via Git.
2. The default ensmallen version downloaded by mlpack was too recent, causing compatibility issues with Armadillo.

The changes update the installation scripts to:

- Use a ZIP download for Armadillo’s specific commit.
- Pin ensmallen to version `1.10.0` for compatibility with mlpack and Armadillo.

These updates ensure the environment can be set up reliably for both manual and Docker-based installations.

## Changes

- Updated `install_lib.sh` to download Armadillo commit `48b45db6ca1d2839e42332dcdf04f55dcec83e20` as a ZIP from GitLab, bypassing the unavailable Git checkout.
- Modified `install_lib.sh` to install ensmallen `1.10.0` from ensmallen.org before building mlpack, ensuring compatibility with Armadillo.
- Adjusted `install_env.sh` to use the pre-installed ensmallen with `-DENSMALLEN_INCLUDE_DIR` instead of `-DDOWNLOAD_ENSMALLEN=ON`.

## Testing

- [x] Verified the updated `install_env.sh` works in a Docker container (Ubuntu-based image with `wget`, `unzip`, and `tar` installed).
- [x] Tested on WSL Ubuntu 18.04, confirming successful installation of all libraries, including Armadillo and mlpack with ensmallen `1.10.0`.
- [x] Ensured the script runs without errors and builds mlpack without missing `ensmallen.hpp`.

## Related Issues

- None explicitly tracked, but this addresses common setup failures reported by many users.

## Notes

This repository appears to be inactive, but these changes are intended for anyone who has the book and needs to set up the installation environment correctly.
